### PR TITLE
Add internal list of actor configurations

### DIFF
--- a/Source/FSharp.Api/ActorExpression.fs
+++ b/Source/FSharp.Api/ActorExpression.fs
@@ -51,6 +51,12 @@ let actor<'a> = Builders.ActorBuilder()
 module ActorRegister = 
     
     open Orleankka
+    open Orleankka.FSharp
+
+    let actorConfigs = new System.Collections.Generic.List<Configurations.ActorConfiguration>()
+
+    let add (actor:Configurations.ActorConfiguration) =
+        actorConfigs.Add(actor)
     
     type FSharpInvoker(body: obj -> Task<obj>) = 
         interface IActorInvoker with 
@@ -72,8 +78,7 @@ module ActorRegister =
         actor.Activator <- activator
         
         actor :> EndpointConfiguration
-            
-        
+
 
     type FSharpActorSystemConfiguratorExtention() = 
         inherit ActorSystemConfiguratorExtension()
@@ -131,5 +136,5 @@ module RegistrationExample =
 //    let inline createFSharpClient config =
 //        ActorSystem.Configure().Client().From(config).FSharp().Done()
 
-   let inline createPlayground conf= 
-      ActorSystem.Configure().Playground().FSharp(fun x->x.RegisterConfigs( conf )).Done()
+   let inline createPlayground () = 
+      ActorSystem.Configure().Playground().FSharp(fun x->x.RegisterConfigs( ActorRegister.actorConfigs )).Done()

--- a/Source/FSharp.Demo.HelloWorld/Program.fs
+++ b/Source/FSharp.Demo.HelloWorld/Program.fs
@@ -11,7 +11,7 @@ type Message =
 
 open ActorExpression
 
-let myActors = new System.Collections.Generic.List<Configurations.ActorConfiguration>()
+// let myActors = new System.Collections.Generic.List<Configurations.ActorConfiguration>()
 
 actor {
    typeName "defined"
@@ -20,7 +20,7 @@ actor {
          msg.GetType().FullName |> printfn "received %s" 
          1 |> response
 
-)} |> myActors.Add
+)} |> ActorRegister.add
 
 actor {
    typeName "counter"
@@ -31,14 +31,14 @@ actor {
          printfn "state is %d" state
          state |> response
 
-)} |> myActors.Add
+)} |> ActorRegister.add
 
 [<EntryPoint>]
 let main argv = 
 
    printfn "Running demo. Booting cluster might take some time ...\n"
 
-   let system = ActorExpression.RegistrationExample.createPlayground( myActors ) 
+   let system = ActorExpression.RegistrationExample.createPlayground() 
    system.Start()
    let ref = system.ActorOf("defined","@")
 


### PR DESCRIPTION
I though it might be useful to move responsibility to store
list of registered actors to our side, providing end user just one method
```
add (actorconfig) = ...
```