### PR TITLE
Delete unused properties from StreamRefMock.cs

### DIFF
--- a/Source/Orleankka.TestKit/StreamRefMock.cs
+++ b/Source/Orleankka.TestKit/StreamRefMock.cs
@@ -20,10 +20,6 @@ namespace Orleankka.TestKit
         [NonSerialized] readonly List<StreamSubscriptionMock> subscriptions = new List<StreamSubscriptionMock>();
         public IEnumerable<StreamSubscriptionMock> RecordedSubscriptions => subscriptions;
 
-        public StreamFilter Filter { get; private set; }
-        public Actor Subscribed    { get; private set; }
-        public Actor Resumed       { get; private set; }
-
         internal StreamRefMock(StreamPath path, SerializationOptions serialization)
             : base(path)
         {


### PR DESCRIPTION
Fix for #129 