### PR TITLE
use .ToList for RemindersMock.Registered()

### DIFF
--- a/Source/Orleankka.TestKit/ReminderServiceMock.cs
+++ b/Source/Orleankka.TestKit/ReminderServiceMock.cs
@@ -31,7 +31,7 @@ namespace Orleankka.TestKit
         }
 
         public Task<bool> IsRegistered(string id) => Task.FromResult(reminders.ContainsKey(id));
-        public Task<IEnumerable<string>> Registered() => Task.FromResult(reminders.Keys.AsEnumerable());
+        public Task<IEnumerable<string>> Registered() => Task.FromResult(reminders.Keys.ToList().AsEnumerable());
 
         public IEnumerator<RecordedReminder> GetEnumerator() => reminders.Values.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/Source/Orleankka.TestKit/TimerServiceMock.cs
+++ b/Source/Orleankka.TestKit/TimerServiceMock.cs
@@ -64,8 +64,8 @@ namespace Orleankka.TestKit
         public bool IsRegistered(string id) => timers.ContainsKey(id);
         public bool IsRegistered(Func<Task> callback) => IsRegistered(callback.Method.Name);
 
-        public IEnumerable<string> Registered() => timers.Keys;
-        public RecordedTimerRequest[] Requests => requests.ToArray(); 
+        public IEnumerable<string> Registered() => timers.Keys.ToList();
+        public RecordedTimerRequest[] Requests => requests.ToArray();
 
         public IEnumerator<RecordedTimer> GetEnumerator() => timers.Values.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
a fix for following scenario

```

        [Test]
        public async Task blabla()
        {
            await TopicCreated();

            IsTrue(() => Reminders.Count() == 2);

			//throws collection modified exception
            await Task.WhenAll(topic.Reminders.Registered().Result.Select(r => topic.Reminders.Unregister(r)));
        }
```

Signed-off-by: A. Prooks <aprooks@live.ru>