### PR TITLE
Adding async query to see if they are handled correctly

### DIFF
--- a/Source/Orleankka.Runtime/Dispatcher.cs
+++ b/Source/Orleankka.Runtime/Dispatcher.cs
@@ -12,6 +12,7 @@ using Orleans.Configuration;
 
 namespace Orleankka
 {
+    using System.Collections.Concurrent;
     using Utility;
 
     public interface IDispatcherRegistry
@@ -21,9 +22,9 @@ namespace Orleankka
 
     class DispatcherRegistry : IDispatcherRegistry
     {
-        static readonly Dictionary<Type, Dispatcher> dispatchers = new Dictionary<Type, Dispatcher>();
+        static readonly ConcurrentDictionary<Type, Dispatcher> dispatchers = new ConcurrentDictionary<Type, Dispatcher>();
 
-        public void Register(Type type, Dispatcher dispatcher) => dispatchers.Add(type, dispatcher);
+        public void Register(Type type, Dispatcher dispatcher) => dispatchers.TryAdd(type, dispatcher);
         public Dispatcher GetDispatcher(Type type) => dispatchers[type];
     }
 

--- a/Tests/Orleankka.Tests/Features/Strongly_typed_actors.cs
+++ b/Tests/Orleankka.Tests/Features/Strongly_typed_actors.cs
@@ -18,6 +18,9 @@ namespace Orleankka.Features
         [Serializable]
         public class TestActorQuery : Query<ITestActor, long> {}
 
+        [Serializable]
+        public class TestActorQueryAsync : Query<ITestActor, string> { }
+
         public interface ITestActor : IActorGrain, IGrainWithStringKey
         {}
 
@@ -25,6 +28,7 @@ namespace Orleankka.Features
         {
             void On(TestActorCommand msg) {}
             long On(TestActorQuery msg) => msg.Response(42);
+            async Task<string> On(TestActorQueryAsync msg) => await Task.FromResult(msg.Response("In base 13, what is 6 multiplied by 9?"));
         }
 
         [Serializable]
@@ -63,6 +67,18 @@ namespace Orleankka.Features
 
                 Assert.DoesNotThrowAsync(async () => await actor.Tell(new TestActorCommand()));
                 Assert.That(await actor.Ask(new TestActorQuery()), Is.EqualTo(42));
+            }
+
+            [Test]
+            public async Task Request_response_async()
+            {
+                var actor = system.TypedActorOf<ITestActor>("foo");
+
+                // below won't compile
+                // actor.Tell(new object());
+
+                Assert.DoesNotThrowAsync(async () => await actor.Tell(new TestActorCommand()));
+                Assert.That(await actor.Ask(new TestActorQueryAsync()), Is.EqualTo("In base 13, what is 6 multiplied by 9?"));
             }
 
             [Test]


### PR DESCRIPTION
Had a bug locally where async queries with strongly typed actors were not working. Added this test to see if Orleankka was affected. (It's not)