### PR TITLE
ActorPath.For now also works with a class that implements IActorGrain as the type parameter

### DIFF
--- a/Tests/Orleankka.Tests/Checks/ActorPathFixture.cs
+++ b/Tests/Orleankka.Tests/Checks/ActorPathFixture.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+
+using Orleankka.Testing;
+
+namespace Orleankka.Checks
+{
+    [TestFixture]
+    public class ActorPathFixture
+    {
+        [Test]
+        public void ActorPath_from_class_and_interface_equal()
+        {
+            var path = ActorPath.For<ITestActor>("42");
+            var path1 = ActorPath.For<TestActor>("42");
+
+            Assert.True(path == path1);
+            Assert.True(path.Equals(path1));
+        }
+    }
+}

--- a/Tests/Orleankka.Tests/Checks/ActorRefFixture.cs
+++ b/Tests/Orleankka.Tests/Checks/ActorRefFixture.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 
+using Orleankka.Testing;
+
 using Orleans;
 
 namespace Orleankka.Checks
@@ -7,12 +9,6 @@ namespace Orleankka.Checks
     [TestFixture]
     public class ActorRefFixture
     {
-        interface ITestActor : IActorGrain, IGrainWithStringKey
-        {}
-
-        class TestActor : DispatchActorGrain, ITestActor
-        {}
-
         [Test]
         public void Equatable_by_path()
         {

--- a/Tests/Orleankka.Tests/Testing/TestActor.cs
+++ b/Tests/Orleankka.Tests/Testing/TestActor.cs
@@ -1,0 +1,10 @@
+﻿using Orleans;
+
+namespace Orleankka.Testing
+{
+    interface ITestActor : IActorGrain, IGrainWithStringKey
+    { }
+
+    class TestActor : DispatchActorGrain, ITestActor
+    { }
+}


### PR DESCRIPTION
ActorPath.ActorPath For(Type @interface, string id) now check if the supplied type parameter is an interface, if not it finds the appropriate interface. I also added a test, might be a bit overkill for this change?
