### PR TITLE
example test of orleankka implict stream subscriptions

### DIFF
--- a/Tests/Orleankka.Tests/Features/Implicit_stream_subscriptions.cs
+++ b/Tests/Orleankka.Tests/Features/Implicit_stream_subscriptions.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleankka.Features
+{
+    namespace Implicit_stream_subscriptions
+    {
+        using Meta;
+        using NUnit.Framework;
+        using Orleans;
+
+        using Testing;
+        
+        public record CreateMessage : Command;
+        public record MessageCreated : Event;
+        public record GetMessages : Query<List<object>>;
+
+        public interface ITestProducerActor : IActorGrain, IGrainWithStringKey
+        { }
+
+        public interface ITestConsumerActor : IActorGrain, IGrainWithStringKey
+        { }
+
+        public class TestProducerActor : DispatchActorGrain, ITestProducerActor
+        {
+            string SelfStreamPath() => $"{nameof(TestProducerActor)}:{GrainReference.GrainId.Key}-Events";
+            StreamRef<object> SelfStream() => System.StreamOf<object>("sms", SelfStreamPath());
+            Task Handle(CreateMessage c) => SelfStream().Publish(new MessageCreated());
+        }
+
+        // Example of what we did before:
+        // Filter by {provider}:/^{actor_name}:{actor_id}-{stream_type}/
+        // Possibility to select the actor `Id` with `Target`
+        // Possibility to provider a `Filter` for messages
+        // [StreamSubscription(Source = "sms:/^TestProducerActor:(?<id>.*)-Events/", Target = "id", Filter = null)]
+        // [StreamSubscription(Source = "sms:/^TestProducerActor:(?<id>.*)-Events/", Target = "{id}", Filter = "*")]
+        // [StreamSubscription(Source = "sms:/^TestProducerActor:(?<id>.*)-Events/", Target = "Correlate()", Filter = "Filter()")]
+        // how can we achieve this now?
+        [ImplicitStreamSubscription]
+        public class TestConsumerActor : DispatchActorGrain, ITestConsumerActor
+        {
+            readonly List<object> received = new List<object>();
+
+            public static string Correlate(object item) => item is MessageCreated ? "id" : "other_id";
+            public static bool Filter(object item) => item is MessageCreated;
+
+            void On(StreamItem<object> x) => received.Add(x.Item);
+            List<object> On(GetMessages x) => received;
+        }
+
+        [TestFixture]
+        [RequiresSilo]
+        class Tests
+        {
+            static readonly TimeSpan timeout = TimeSpan.FromMilliseconds(1000);
+            IActorSystem system;
+
+            [SetUp]
+            public void SetUp() =>
+                system = TestActorSystem.Instance;
+
+            [Test]
+            public async Task Implicit_stream_subscription()
+            {
+                var publisher = system.ActorOf<ITestProducerActor>("id");
+                await publisher.Tell(new CreateMessage());
+
+                await Task.Delay(timeout);
+                
+                var consumer = system.ActorOf<ITestConsumerActor>("id");
+                var received = await consumer.Ask(new GetMessages());
+
+                Assert.That(received.Count, Is.EqualTo(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I don't have a Orleans solution on how to achieve what was possible before. 
I don't know of a way to provide a regex stream id filter. 
I don't know of a way to intercept stream messages before they arrive to the actor, we need to do this to select the actor id, sometimes this id is calculated from data in the message body.
Filtering would also be a "nice to have" so that we don't need to active actors for no reason.

I've added what we used in orleankka 3.x with commented attributes on `TestConsumerActor`

Related to #182