### PR TITLE
revive legacy stream subscriptions

### DIFF
--- a/Source/Orleankka.Legacy.Runtime/ActorAttributes.cs
+++ b/Source/Orleankka.Legacy.Runtime/ActorAttributes.cs
@@ -2,6 +2,14 @@
 
 namespace Orleankka.Legacy
 {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class StreamSubscriptionAttribute : Attribute
+    {
+        public string Source;
+        public string Target;
+        public string Filter;
+    }
+
     [AttributeUsage(AttributeTargets.Method)]
     public sealed class BehaviorAttribute : Attribute
     {

--- a/Source/Orleankka.Legacy.Runtime/Streams/CompositeStreamPubSub.cs
+++ b/Source/Orleankka.Legacy.Runtime/Streams/CompositeStreamPubSub.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+
+namespace Orleankka.Legacy.Streams
+{
+    /// <summary>
+    ///     StreamPubSub that combines orleans `StreamPubSubImpl` and <see cref="StreamSubscriptionPubSub" />.
+    /// </summary>
+    class CompositeStreamPubSub : IStreamPubSub
+    {
+        readonly IStreamPubSub orleansPubSub;
+        readonly StreamSubscriptionPubSub streamSubscriptionPubSub;
+
+        public CompositeStreamPubSub(IStreamPubSub orleansPubSub, StreamSubscriptionPubSub streamSubscriptionPubSub)
+        {
+            this.orleansPubSub = orleansPubSub;
+            this.streamSubscriptionPubSub = streamSubscriptionPubSub;
+        }
+
+        public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
+        {
+            var orleansRes = await orleansPubSub.RegisterProducer(streamId, streamProducer);
+            var streamSubscriptionRes = await streamSubscriptionPubSub.RegisterProducer(streamId, streamProducer);
+            orleansRes.UnionWith(streamSubscriptionRes);
+            return orleansRes;
+        }
+
+        public Task UnregisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
+        {
+            return orleansPubSub.UnregisterProducer(streamId, streamProducer);
+        }
+
+        public Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, GrainId streamConsumer, string filterData)
+        {
+            return streamSubscriptionPubSub.IsStreamSubscriber(streamConsumer, streamId)
+            ? streamSubscriptionPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData)
+            : orleansPubSub.RegisterConsumer(subscriptionId, streamId, streamConsumer, filterData);
+        }
+
+        public Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
+        {
+            return streamSubscriptionPubSub.IsStreamSubscriber(subscriptionId, streamId)
+            ? streamSubscriptionPubSub.UnregisterConsumer(subscriptionId, streamId)
+            : orleansPubSub.UnregisterConsumer(subscriptionId, streamId);
+        }
+
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
+        {
+            return orleansPubSub.ProducerCount(streamId);
+        }
+
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
+        {
+            return orleansPubSub.ConsumerCount(streamId);
+        }
+
+        public async Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, GrainId streamConsumer)
+        {
+            if (streamConsumer != default)
+            {
+                return streamSubscriptionPubSub.IsStreamSubscriber(streamConsumer, streamId)
+                ? await streamSubscriptionPubSub.GetAllSubscriptions(streamId, streamConsumer)
+                : await orleansPubSub.GetAllSubscriptions(streamId, streamConsumer);
+            }
+
+            var streamSubscriptionSubs = await streamSubscriptionPubSub.GetAllSubscriptions(streamId);
+            var orleansSubs = await orleansPubSub.GetAllSubscriptions(streamId);
+            return streamSubscriptionSubs.Concat(orleansSubs).ToList();
+        }
+
+        public GuidId CreateSubscriptionId(QualifiedStreamId streamId, GrainId streamConsumer)
+        {
+            return streamSubscriptionPubSub.IsStreamSubscriber(streamConsumer, streamId)
+            ? streamSubscriptionPubSub.CreateSubscriptionId(streamId, streamConsumer)
+            : orleansPubSub.CreateSubscriptionId(streamId, streamConsumer);
+        }
+
+        public Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId)
+        {
+            return streamSubscriptionPubSub.IsStreamSubscriber(subscriptionId, streamId)
+            ? streamSubscriptionPubSub.FaultSubscription(streamId, subscriptionId)
+            : orleansPubSub.FaultSubscription(streamId, subscriptionId);
+        }
+    }
+}

--- a/Source/Orleankka.Legacy.Runtime/Streams/StreamProviderPubSubRegistrar.cs
+++ b/Source/Orleankka.Legacy.Runtime/Streams/StreamProviderPubSubRegistrar.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Orleans;
+using Orleans.Providers;
+using Orleans.Runtime;
+using Orleans.Streams;
+
+namespace Orleankka.Legacy.Streams
+{
+    class StreamProviderPubSubRegistrar : ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver
+    {
+        public StreamProviderPubSubRegistrar(IServiceProvider serviceProvider, string name)
+        {
+            RegisterStreamSubscriptionPubSub(serviceProvider, name);
+        }
+
+        Task ILifecycleObserver.OnStart(CancellationToken _)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ILifecycleObserver.OnStop(CancellationToken _)
+        {
+            return Task.CompletedTask;
+        }
+
+        void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle observer)
+        {
+            observer.Subscribe(nameof(StreamProviderPubSubRegistrar), ServiceLifecycleStage.AfterRuntimeGrainServices, this);
+        }
+
+        static void RegisterStreamSubscriptionPubSub(IServiceProvider provider, string streamProviderName)
+        {
+            var streamProvider = provider.GetServiceByName<IStreamProvider>(streamProviderName);
+
+            var streamRuntime = GetStreamProviderRuntime(streamProvider);
+            var orleansPubSubField = GetOrleansPubSubField(streamRuntime);
+            var orleansPubSub = (IStreamPubSub)orleansPubSubField.GetValue(streamRuntime);
+
+            var streamSubscriptionPubSub = ActivatorUtilities.CreateInstance<StreamSubscriptionPubSub>(provider);
+            var compositePubSub = ActivatorUtilities.CreateInstance<CompositeStreamPubSub>(provider, orleansPubSub, streamSubscriptionPubSub);
+
+            orleansPubSubField.SetValue(streamRuntime, compositePubSub);
+        }
+
+        static IProviderRuntime GetStreamProviderRuntime(IStreamProvider streamProvider)
+        {
+            var streamProviderType = streamProvider.GetType();
+            var runtime = streamProviderType.GetField("runtime", BindingFlags.NonPublic | BindingFlags.Instance);
+            Debug.Assert(runtime != null);
+            return (IProviderRuntime)runtime.GetValue(streamProvider);
+        }
+
+        static FieldInfo GetOrleansPubSubField(IProviderRuntime streamProviderRuntime)
+        {
+            var streamProviderRuntimeType = streamProviderRuntime.GetType();
+            var streamPubSub = streamProviderRuntimeType.GetField("combinedGrainBasedAndImplicitPubSub", BindingFlags.NonPublic | BindingFlags.Instance);
+            Debug.Assert(streamPubSub != null);
+            return streamPubSub;
+        }
+    }
+}

--- a/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionMessageDeliverer.cs
+++ b/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionMessageDeliverer.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Orleans;
+using Orleans.Placement;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+
+namespace Orleankka.Legacy.Streams
+{
+    interface IStreamSubscriptionMessageDeliverer : IGrainWithStringKey
+    { }
+
+    [PreferLocalPlacement]
+    class StreamSubscriptionMessageDeliverer : Grain, IStreamSubscriptionMessageDeliverer, IStreamSubscriptionObserver, IAsyncObserver<object>
+    {
+        readonly StreamSubscriptionTable table;
+
+        public StreamSubscriptionMessageDeliverer(StreamSubscriptionTable table)
+        {
+            this.table = table;
+        }
+
+        StreamSubscriptionMatch SubscriptionMatch { get; set; }
+        QualifiedStreamId StreamId { get; set; }
+        Guid SubscriptionId { get; set; }
+
+        public Task OnNextAsync(object item, StreamSequenceToken token = null)
+        {
+            if (!SubscriptionMatch.ShouldSendMessage(item))
+                return Task.CompletedTask;
+
+            return OnNextAsyncSend(item, token);
+        }
+
+        public Task OnCompletedAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnErrorAsync(Exception ex)
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
+        {
+            var qualifiedStreamId = new QualifiedStreamId(handleFactory.ProviderName, handleFactory.StreamId);
+            var subscriptionMatch = table.GetStreamSubscription(qualifiedStreamId, handleFactory.SubscriptionId.Guid);
+
+            SubscriptionMatch = subscriptionMatch;
+            StreamId = qualifiedStreamId;
+            SubscriptionId = handleFactory.SubscriptionId.Guid;
+
+            var handle = handleFactory.Create<object>();
+            await handle.ResumeAsync(this);
+        }
+
+        async Task OnNextAsyncSend(object item, StreamSequenceToken token = null)
+        {
+            var target = SubscriptionMatch.SelectTarget(item);
+            var actor = GrainFactory.GetGrain(SubscriptionMatch.InterfaceType, target).AsReference<IActorGrain>();
+            RequestContext.Set(nameof(StreamSequenceToken), token);
+            await actor.ReceiveTell(item);
+        }
+    }
+}

--- a/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionPubSub.cs
+++ b/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionPubSub.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Orleans.Runtime;
+using Orleans.Streams;
+using Orleans.Streams.Core;
+
+namespace Orleankka.Legacy.Streams
+{
+    /// <summary>
+    ///     StreamPubSub implementation for <see cref="StreamSubscriptionAttribute" />
+    /// </summary>
+    class StreamSubscriptionPubSub : IStreamPubSub
+    {
+        readonly StreamSubscriptionTable streamSubscriptionTable;
+
+        public StreamSubscriptionPubSub(StreamSubscriptionTable streamSubscriptionTable)
+        {
+            this.streamSubscriptionTable = streamSubscriptionTable;
+        }
+
+        public Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
+        {
+            var implicitStreamSubscriptions = streamSubscriptionTable.GetStreamSubscriptions(streamId);
+
+            ISet<PubSubSubscriptionState> result = new HashSet<PubSubSubscriptionState>();
+            foreach (var subscription in implicitStreamSubscriptions)
+            {
+                var subscriptionId = GuidId.GetGuidId(streamSubscriptionTable.GetSubscriptionId(subscription, streamId));
+                var streamConsumer = streamSubscriptionTable.GetStreamSubscriptionMessageDeliverer(subscription);
+                result.Add(new PubSubSubscriptionState(subscriptionId, streamId, streamConsumer));
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task UnregisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task RegisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId, GrainId streamConsumer, string filterData)
+        {
+            if (!IsStreamSubscriber(streamConsumer, streamId))
+                throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit stream subscriptions are supported.");
+
+            return Task.CompletedTask;
+        }
+
+        public Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
+        {
+            if (!IsStreamSubscriber(subscriptionId, streamId))
+                throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit stream subscriptions are supported.");
+
+            return Task.CompletedTask;
+        }
+
+        public Task<int> ProducerCount(QualifiedStreamId streamId)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task<int> ConsumerCount(QualifiedStreamId streamId)
+        {
+            return Task.FromResult(0);
+        }
+
+        public Task<List<StreamSubscription>> GetAllSubscriptions(QualifiedStreamId streamId, GrainId streamConsumer = new())
+        {
+            if (!IsStreamSubscriber(streamConsumer, streamId))
+                return Task.FromResult(new List<StreamSubscription>());
+
+            if (streamConsumer != default)
+            {
+                var subscriptionId = CreateSubscriptionId(streamId, streamConsumer);
+                return Task.FromResult(new List<StreamSubscription> { new(subscriptionId.Guid, streamId.ProviderName, streamId, streamConsumer) });
+            }
+
+            var implicitStreamSubscriptions = streamSubscriptionTable.GetStreamSubscriptions(streamId);
+            var result = new List<StreamSubscription>();
+            foreach (var subscription in implicitStreamSubscriptions)
+            {
+                var subscriptionId = streamSubscriptionTable.GetSubscriptionId(subscription, streamId);
+                var consumer = streamSubscriptionTable.GetStreamSubscriptionMessageDeliverer(subscription);
+                result.Add(new StreamSubscription(subscriptionId, streamId.ProviderName, streamId.StreamId, consumer));
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public GuidId CreateSubscriptionId(QualifiedStreamId streamId, GrainId streamConsumer)
+        {
+            if (!IsStreamSubscriber(streamConsumer, streamId))
+                throw new ArgumentOutOfRangeException(streamId.ToString(), "Only implicit stream subscriptions are supported.");
+
+            return GuidId.GetGuidId(streamSubscriptionTable.GetSubscriptionId(streamConsumer, streamId));
+        }
+
+        public Task<bool> FaultSubscription(QualifiedStreamId streamId, GuidId subscriptionId)
+        {
+            return Task.FromResult(false);
+        }
+
+        internal bool IsStreamSubscriber(GuidId subscriptionId, QualifiedStreamId streamId)
+        {
+            return streamSubscriptionTable.IsStreamSubscriptionSubscriber(subscriptionId, streamId);
+        }
+
+        internal bool IsStreamSubscriber(GrainId streamConsumer, QualifiedStreamId streamId)
+        {
+            var implicitStreamSubscriptions = streamSubscriptionTable.GetStreamSubscriptions(streamId);
+            if (implicitStreamSubscriptions.Any(subscription => streamSubscriptionTable.GetStreamSubscriptionMessageDeliverer(subscription) == streamConsumer))
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionSpecification.cs
+++ b/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionSpecification.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+using Orleankka.Utility;
+
+using Orleans.Runtime;
+
+namespace Orleankka.Legacy.Streams
+{
+    static class StreamSubscriptionSpecificationBuilder
+    {
+        internal static StreamSubscriptionSpecification Build(Type grainType, StreamSubscriptionAttribute attribute, IDispatcherRegistry registry)
+        {
+            if (string.IsNullOrWhiteSpace(attribute.Source))
+                throw InvalidSpecification(grainType, "has null or whitespace only value of Source");
+
+            if (string.IsNullOrWhiteSpace(attribute.Target))
+                throw InvalidSpecification(grainType, "has null or whitespace only value of Target");
+
+            if (attribute.Filter != null && string.IsNullOrWhiteSpace(attribute.Filter))
+                throw InvalidSpecification(grainType, "has whitespace only value of Filter");
+
+            var parts = attribute.Source.Split(new[] { ":" }, 2, StringSplitOptions.None);
+            if (parts.Length != 2)
+                throw InvalidSpecification(grainType, $"has invalid Source specification: {attribute.Source}");
+
+            var provider = parts[0];
+            var source = parts[1];
+
+            var matcher = BuildMatcher(null, source, attribute.Target);
+            var selector = BuildTargetSelector(attribute.Target, grainType);
+            var filter = BuildFilter(attribute.Filter, grainType, registry);
+
+            return new StreamSubscriptionSpecification(grainType, provider, matcher, selector, filter);
+        }
+
+        static Exception InvalidSpecification(Type actor, string error)
+        {
+            var message = $"StreamSubscription attribute defined on '{actor}' {error}";
+            return new InvalidOperationException(message);
+        }
+
+        static StreamMatchesFunc BuildMatcher(string @namespace, string source, string target)
+        {
+            var isRegex = source.StartsWith("/") && source.EndsWith("/");
+            if (!isRegex)
+                return (StreamId stream, out string targetId) =>
+                {
+                    var ns = stream.GetNamespace();
+                    var key = stream.GetKeyAsString();
+
+                    if (ns == @namespace && key == source)
+                    {
+                        targetId = target;
+                        return true;
+                    }
+
+                    targetId = null;
+                    return false;
+                };
+
+            var pattern = new Regex(source.Substring(1, source.Length - 2), RegexOptions.Compiled);
+            var generator = new Regex(@"(?<placeholder>\{[^\}]+\})", RegexOptions.Compiled);
+
+            return (StreamId stream, out string targetId) =>
+            {
+                var ns = stream.GetNamespace();
+                var key = stream.GetKeyAsString();
+
+                if (ns == @namespace)
+                {
+                    var match = pattern.Match(key);
+                    if (match.Success)
+                    {
+                        targetId = generator.Replace(target, m =>
+                        {
+                            var placeholder = m.Value.Substring(1, m.Value.Length - 2);
+                            return match.Groups[placeholder].Value;
+                        });
+
+                        return true;
+                    }
+                }
+
+                targetId = null;
+                return false;
+            };
+        }
+
+        static ShouldSendMessageFunc BuildFilter(string filter, Type actor, IDispatcherRegistry registry)
+        {
+            if (filter == null)
+                return item => registry.GetDispatcher(actor).CanHandle(item.GetType());
+
+            if (filter == "*")
+                return _ => true;
+
+            if (!filter.EndsWith("()"))
+                throw new InvalidOperationException("Filter string value is missing '()' function designator");
+
+            var method = GetStaticMethod(filter, actor);
+            if (method == null)
+                throw new InvalidOperationException("Filter function should be a static method");
+
+            return (ShouldSendMessageFunc)method.CreateDelegate(typeof(ShouldSendMessageFunc));
+        }
+
+        static SelectTargetFunc BuildTargetSelector(string target, Type actor)
+        {
+            if (!target.EndsWith("()"))
+                return null;
+
+            var method = GetStaticMethod(target, actor);
+            if (method == null)
+                throw new InvalidOperationException("Target function should be a static method");
+
+            return (SelectTargetFunc)method.CreateDelegate(typeof(SelectTargetFunc));
+        }
+
+        static MethodInfo GetStaticMethod(string methodString, Type type)
+        {
+            var methodName = methodString.Remove(methodString.Length - 2, 2);
+            return type.GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        }
+    }
+
+    delegate bool StreamMatchesFunc(StreamId streamId, out string target);
+
+    delegate string SelectTargetFunc(object message);
+
+    delegate bool ShouldSendMessageFunc(object message);
+
+    class StreamSubscriptionSpecification
+    {
+        readonly ShouldSendMessageFunc filterMessageFunc;
+        readonly StreamMatchesFunc matchStreamIdMatcher;
+        readonly SelectTargetFunc targetSelector;
+
+        public StreamSubscriptionSpecification(
+        Type actorType,
+        string providerName,
+        StreamMatchesFunc matchStreamFunc,
+        SelectTargetFunc selectTargetFunc,
+        ShouldSendMessageFunc filterMessageFunc)
+        {
+            Requires.NotNull(actorType, nameof(actorType));
+            Requires.NotNullOrWhitespace(providerName, nameof(providerName));
+            Requires.NotNull(matchStreamFunc, nameof(matchStreamFunc));
+
+            ActorType = actorType;
+            InterfaceType = ActorGrain.InterfaceOf(actorType);
+            ProviderName = providerName;
+
+            matchStreamIdMatcher = matchStreamFunc;
+            targetSelector = selectTargetFunc;
+            this.filterMessageFunc = filterMessageFunc;
+        }
+
+        public Type ActorType { get; }
+        public Type InterfaceType { get; }
+        public string ProviderName { get; }
+
+        public bool IsMatch(StreamId streamId, out StreamSubscriptionMatch match)
+        {
+            if (matchStreamIdMatcher(streamId, out var target))
+            {
+                match = new StreamSubscriptionMatch(InterfaceType, target, targetSelector, filterMessageFunc);
+                return true;
+            }
+
+            match = null;
+            return false;
+        }
+    }
+
+    class StreamSubscriptionMatch
+    {
+        public StreamSubscriptionMatch(Type interfaceType, string target, SelectTargetFunc actorIdSelector, ShouldSendMessageFunc shouldSendMessage)
+        {
+            InterfaceType = interfaceType;
+            Target = target;
+            SelectTarget = actorIdSelector ?? (_ => target);
+            ShouldSendMessage = shouldSendMessage;
+        }
+
+        public Type InterfaceType { get; }
+        public string Target { get; }
+        public SelectTargetFunc SelectTarget { get; }
+        public ShouldSendMessageFunc ShouldSendMessage { get; }
+
+        public string MessageDelivererId => $"{InterfaceType.FullName}/{Target}";
+    }
+}

--- a/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionTable.cs
+++ b/Source/Orleankka.Legacy.Runtime/Streams/StreamSubscriptionTable.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Microsoft.Extensions.Options;
+
+using Orleankka.Utility;
+
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime;
+
+namespace Orleankka.Legacy.Streams
+{
+    class StreamSubscriptionTable
+    {
+        readonly IGrainFactory grainFactory;
+        readonly Dictionary<string, List<StreamSubscriptionSpecification>> streamSubscriptions;
+
+        public StreamSubscriptionTable(IOptions<GrainTypeOptions> grainTypeOptions, IGrainFactory grainFactory, IDispatcherRegistry registry)
+        {
+            Requires.NotNull(grainTypeOptions, nameof(grainTypeOptions));
+            Requires.NotNull(grainTypeOptions.Value, nameof(grainTypeOptions.Value));
+            Requires.NotNull(grainFactory, nameof(grainFactory));
+            Requires.NotNull(registry, nameof(registry));
+
+            this.grainFactory = grainFactory;
+            this.streamSubscriptions = FindStreamSubscriptions(grainTypeOptions.Value.Classes, registry);
+        }
+
+        internal GrainId GetStreamSubscriptionMessageDeliverer(StreamSubscriptionMatch subscription)
+        {
+            return grainFactory.GetGrain(typeof(IStreamSubscriptionMessageDeliverer), subscription.MessageDelivererId).GetGrainId();
+        }
+
+        internal Guid GetSubscriptionId(StreamSubscriptionMatch subscription, QualifiedStreamId streamId)
+        {
+            var streamSubscriber = grainFactory.GetGrain(subscription.InterfaceType, subscription.Target).GetGrainId();
+            return MakeSubscriptionId(streamSubscriber.Type, streamId);
+        }
+
+        internal Guid GetSubscriptionId(GrainId streamSubscriber, QualifiedStreamId streamId)
+        {
+            return MakeSubscriptionId(streamSubscriber.Type, streamId);
+        }
+
+        internal bool IsStreamSubscriptionSubscriber(GuidId subscriptionId, QualifiedStreamId streamId)
+        {
+            var possibleStreamSubscriptions = GetStreamSubscriptions(streamId);
+            return HasImplicitSubscriptionMark(subscriptionId.Guid) && possibleStreamSubscriptions.Any();
+        }
+
+        internal StreamSubscriptionMatch GetStreamSubscription(QualifiedStreamId streamId, Guid subscriptionId)
+        {
+            foreach (var streamSubscription in GetStreamSubscriptions(streamId))
+                if (subscriptionId == GetSubscriptionId(streamSubscription, streamId))
+                    return streamSubscription;
+
+            return null;
+        }
+
+        internal List<StreamSubscriptionMatch> GetStreamSubscriptions(QualifiedStreamId streamId)
+        {
+            if (!this.streamSubscriptions.TryGetValue(streamId.ProviderName, out var specifications))
+                return new List<StreamSubscriptionMatch>(0);
+
+            var resultCollection = new List<StreamSubscriptionMatch>();
+            foreach (var specification in specifications)
+            {
+                if (!specification.IsMatch(streamId.StreamId, out var match))
+                    continue;
+
+                resultCollection.Add(match);
+            }
+
+            return resultCollection;
+        }
+
+        static Dictionary<string, List<StreamSubscriptionSpecification>> FindStreamSubscriptions(HashSet<Type> grainTypes, IDispatcherRegistry registry)
+        {
+            var specifications = new Dictionary<string, List<StreamSubscriptionSpecification>>();
+
+            foreach (var grainType in grainTypes)
+            {
+                var streamSubscriptionAttributes = grainType.GetCustomAttributes<StreamSubscriptionAttribute>(true);
+                var grainSpecifications = streamSubscriptionAttributes.Select(attr => StreamSubscriptionSpecificationBuilder.Build(grainType, attr, registry));
+
+                foreach (var grainSpecification in grainSpecifications)
+                {
+                    if (!specifications.TryGetValue(grainSpecification.ProviderName, out var streams))
+                    {
+                        streams = new List<StreamSubscriptionSpecification>();
+                        specifications[grainSpecification.ProviderName] = streams;
+                    }
+
+                    streams.Add(grainSpecification);
+                }
+            }
+
+            return specifications;
+        }
+
+        /// <summary>
+        ///     Create a subscriptionId that is unique per grainType, streamId, provider combination.
+        /// </summary>
+        static Guid MakeSubscriptionId(GrainType grainType, QualifiedStreamId streamId)
+        {
+            // adjusted code from orleans implicit stream subscription
+            Span<byte> bytes = stackalloc byte[16];
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes, grainType.GetUniformHashCode());
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes[4..], (uint)streamId.StreamId.GetHashCode());
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes[8..], 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(bytes[12..], StableHash.ComputeHash(streamId.ProviderName));
+            return MarkAsImplicitSubscription(new Guid(bytes));
+        }
+
+        static Guid MarkAsImplicitSubscription(Guid subscriptionId)
+        {
+            Span<byte> guidBytes = stackalloc byte[16];
+            subscriptionId.TryWriteBytes(guidBytes);
+            // set high bit of last byte
+            guidBytes[15] |= 0x80;
+            return new Guid(guidBytes);
+        }
+
+        static bool HasImplicitSubscriptionMark(Guid subscriptionId)
+        {
+            Span<byte> guidBytes = stackalloc byte[16];
+            subscriptionId.TryWriteBytes(guidBytes);
+            // return true if high bit of last byte is set
+            return (guidBytes[15] & 0x80) != 0;
+        }
+    }
+}

--- a/Source/Orleankka/LifecycleMessages.cs
+++ b/Source/Orleankka/LifecycleMessages.cs
@@ -6,18 +6,19 @@ namespace Orleankka
     public interface LifecycleMessage
     {}
 
-    [Serializable, Immutable]
+    [Serializable, GenerateSerializer, Immutable]
     public sealed class Activate : LifecycleMessage
     {
         public static readonly Activate External = new Activate();
         public static readonly Activate State = new Activate();
     }
 
-    [Serializable, Immutable]
+    [Serializable, GenerateSerializer, Immutable]
     public sealed class Deactivate : LifecycleMessage
     {
         public Deactivate(DeactivationReason reason = default) => Reason = reason;
 
+        [Id(0)]
         public DeactivationReason Reason { get; }
 
         public static readonly Deactivate External = new(new DeactivationReason(DeactivationReasonCode.ApplicationRequested, "Triggered externally"));

--- a/Source/Orleankka/StreamMessages.cs
+++ b/Source/Orleankka/StreamMessages.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using Orleans.Streams;
+using Orleans;
 
 namespace Orleankka
 {
@@ -241,9 +242,12 @@ namespace Orleankka
         StreamPath Path { get; }
     }
 
+    [GenerateSerializer]
     public abstract class StreamMessage<TItem> : StreamMessage
     {
         public StreamPath Path => Stream.Path;
+
+        [Id(0)]
         public StreamRef<TItem> Stream { get; }
 
         protected StreamMessage(StreamRef<TItem> stream)
@@ -251,28 +255,33 @@ namespace Orleankka
             Requires.NotNull(stream, nameof(stream));
             Stream = stream;
         }
-
     }
 
+    [GenerateSerializer]
     public class StreamItem<TItem> : StreamMessage<TItem>
     {
+        [Id(0)]
         public TItem Item { get; }
+
+        [Id(1)]
         public StreamSequenceToken Token { get; }
 
         public StreamItem(StreamRef<TItem> stream, TItem item, StreamSequenceToken token = null)
-            : base(stream)
+        : base(stream)
         {
             Item = item;
             Token = token;
         }
     }
 
+    [GenerateSerializer]
     public class StreamItemBatch<TItem> : StreamMessage<TItem>
     {
+        [Id(0)]
         public IList<SequentialItem<TItem>> Items { get; }
 
         public StreamItemBatch(StreamRef<TItem> stream, IList<SequentialItem<TItem>> items)
-            : base(stream)
+        : base(stream)
         {
             // ReSharper disable PossibleMultipleEnumeration
             Requires.NotNull(items, nameof(items));
@@ -281,9 +290,13 @@ namespace Orleankka
         }
     }
 
+    [GenerateSerializer]
     public class StreamError : StreamMessage
     {
+        [Id(0)]
         public StreamPath Path { get; }
+
+        [Id(1)]
         public Exception Exception { get; }
 
         public StreamError(StreamPath path, Exception exception)
@@ -297,14 +310,17 @@ namespace Orleankka
         }
     }
 
+    [GenerateSerializer]
     public class StreamCompleted : StreamMessage
     {
+        [Id(0)]
         public StreamPath Path { get; }
 
         public StreamCompleted(StreamPath path)
         {
             if (path == StreamPath.Empty)
                 throw new InvalidOperationException("The stream path is empty");
+
             Path = path;
         }
     }

--- a/Source/Orleankka/StreamPath.cs
+++ b/Source/Orleankka/StreamPath.cs
@@ -48,7 +48,7 @@ namespace Orleankka
         /// <remarks>
         /// This maps to Orleans' stream namespace.
         /// The GUID is not used by Orleankka's stream references and is always Guid.Empty.</remarks>
-        [Id(0)] public readonly string Id;
+        [Id(1)] public readonly string Id;
 
         StreamPath(string provider, string id)
         {

--- a/Tests/Orleankka.Tests/Features/Declarative_stream_subscriptions.cs
+++ b/Tests/Orleankka.Tests/Features/Declarative_stream_subscriptions.cs
@@ -1,0 +1,299 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+using Orleans;
+
+namespace Orleankka.Legacy.Features
+{
+    namespace Declarative_stream_subscriptions
+    {
+        using Meta;
+        using Legacy;
+        using Testing;
+
+        [GenerateSerializer]
+        public class Received : Query<List<string>>
+        { }
+
+        [GenerateSerializer]
+        public class Deactivate : Command
+        { }
+
+        public abstract class TestConsumerActorBase : Actor
+        {
+            protected readonly List<string> received = new List<string>();
+
+            void On(string x) => received.Add(x);
+            void On(long x) => received.Add(x.ToString());
+            List<string> On(Received x) => received.ToList();
+            void On(Deactivate x) => Activation.DeactivateOnIdle();
+        }
+
+        [GenerateSerializer]
+        public class Publish : Command
+        {
+            [Id(0)]
+            public readonly StreamRef<object> Stream;
+            [Id(1)]
+            public readonly object Item;
+
+            public Publish(StreamRef<object> stream, object item)
+            {
+                Stream = stream;
+                Item = item;
+            }
+        }
+
+        public interface ITestProducerActor : IActorGrain, IGrainWithStringKey
+        { }
+
+        public class TestProducerActor : Actor, ITestProducerActor
+        {
+            Task On(Publish x) => x.Stream.Publish(x.Item);
+        }
+
+        class TestCases
+        {
+            readonly string provider;
+            readonly TimeSpan timeout;
+            readonly IActorSystem system;
+
+            public TestCases(string provider, TimeSpan timeout)
+            {
+                this.provider = provider;
+                this.timeout = timeout;
+                system = TestActorSystem.Instance;
+            }
+
+            public async Task Client_to_stream<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "cs");
+
+                await stream.Publish("ce");
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#cs");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received, Is.EquivalentTo(new[] { "ce" }));
+            }
+
+            public async Task Actor_to_stream<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "as");
+
+                await Publish(stream, "ae");
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#as");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received, Is.EquivalentTo(new[] { "ae" }));
+            }
+
+            public async Task Multistream_subscription_with_fixed_ids<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var a = system.StreamOf<object>(provider, "a");
+                var b = system.StreamOf<object>(provider, "b");
+
+                await Publish(a, "a-001");
+                await Publish(b, "b-001");
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#ms");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received, Is.EquivalentTo(new[] { "a-001", "b-001" }));
+            }
+
+            public async Task Multistream_subscription_based_on_regex_matching<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var s1 = system.StreamOf<object>(provider, "INV-001");
+                var s2 = system.StreamOf<object>(provider, "INV-002");
+
+                await Publish(s1, "001");
+                await Publish(s2, "002");
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#msregex");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received, Is.EquivalentTo(new[] { "001", "002" }));
+            }
+
+            public async Task Declared_handler_only_automatic_item_filtering<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "declared-auto");
+
+                await Publish(stream, 123);
+                await Publish(stream, "e-123");
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#auto");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received.Count, Is.EqualTo(1));
+                Assert.That(received[0], Is.EqualTo("e-123"));
+            }
+
+            public async Task Select_all_filter<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "select-all");
+
+                await Publish(stream, 42);
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#select-all");
+                var received = await consumer.Ask(new Received());
+
+                Assert.That(received.Count, Is.EqualTo(1));
+                Assert.That(received[0], Is.EqualTo("42"));
+            }
+
+            public async Task Explicit_filter<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "filtered");
+
+                await Publish(stream, "f-001");
+                await Publish(stream, "f-002");
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#filtered");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received.Count, Is.EqualTo(0));
+            }
+
+            public async Task Dynamic_target_selection<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "dynamic-target");
+
+                await Publish(stream, "red");
+                await Publish(stream, "blue");
+                await Task.Delay(timeout);
+
+                var consumer1 = system.ActorOf<T>("red-pill");
+                var consumer2 = system.ActorOf<T>("blue-pill");
+
+                Assert.That((await consumer1.Ask(new Received()))[0], Is.EqualTo("red"));
+                Assert.That((await consumer2.Ask(new Received()))[0], Is.EqualTo("blue"));
+            }
+
+            public async Task Batch_receive<T>() where T : IActorGrain, IGrainWithStringKey
+            {
+                var stream = system.StreamOf<object>(provider, "batched");
+
+                await stream.Publish(new[] { "i1", "i2" });
+                await Task.Delay(timeout);
+
+                var consumer = system.ActorOf<T>("#batched");
+                var received = await consumer.Ask(new Received());
+                Assert.That(received,
+                    Is.EquivalentTo(new[] { "i1", "i2" }),
+                    "The batch will be unrolled at a grain and items will be delivered to Receive one by one");
+            }
+
+            async Task Publish(StreamRef<object> stream, object item)
+            {
+                var producer = system.ActorOf<ITestProducerActor>("foo");
+                await producer.Tell(new Publish(stream, item));
+            }
+        }
+
+        namespace MemoryStreamProviderVerification
+        {
+            public interface ITestClientToStreamConsumerActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:cs", Target = "#cs")]
+            public class TestClientToStreamConsumerActor : TestConsumerActorBase, ITestClientToStreamConsumerActor
+            { }
+
+            public interface ITestActorToStreamConsumerActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:as", Target = "#as")]
+            public class TestActorToStreamConsumerActor : TestConsumerActorBase, ITestActorToStreamConsumerActor
+            { }
+
+            public interface ITestMultistreamSubscriptionWithFixedIdsActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:a", Target = "#ms")]
+            [StreamSubscription(Source = "sms:b", Target = "#ms")]
+            public class TestMultistreamSubscriptionWithFixedIdsActor : TestConsumerActorBase, ITestMultistreamSubscriptionWithFixedIdsActor
+            { }
+
+            public interface ITestMultistreamRegexBasedSubscriptionActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:/INV-([0-9]+)/", Target = "#msregex")]
+            public class TestMultistreamRegexBasedSubscriptionActor : TestConsumerActorBase, ITestMultistreamRegexBasedSubscriptionActor
+            { }
+
+            public interface ITestDeclaredHandlerOnlyAutomaticFilterActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:declared-auto", Target = "#auto")]
+            public class TestDeclaredHandlerOnlyAutomaticFilterActor : TestConsumerActorBase, ITestDeclaredHandlerOnlyAutomaticFilterActor
+            { }
+
+            public interface ITestSelectAllFilterActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:select-all", Target = "#select-all", Filter = "*")]
+            public class TestSelectAllFilterActor : TestConsumerActorBase, ITestSelectAllFilterActor
+            {
+                public override Task<object> OnReceive(object message)
+                {
+                    if (message is int)
+                    {
+                        received.Add(message.ToString());
+                        return Task.FromResult<object>(null);
+                    }
+
+                    return base.OnReceive(message);
+                }
+            }
+
+            public interface ITestExplicitFilterActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:filtered", Target = "#filtered", Filter = "SelectItem()")]
+            public class TestExplicitFilterActor : TestConsumerActorBase, ITestExplicitFilterActor
+            {
+                public static bool SelectItem(object item) => false;
+            }
+
+            public interface ITestDynamicTargetSelectorActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:dynamic-target", Target = "ComputeTarget()")]
+            public class TestDynamicTargetSelectorActor : TestConsumerActorBase, ITestDynamicTargetSelectorActor
+            {
+                public static string ComputeTarget(object item) => $"{item}-pill";
+            }
+
+            public interface ITestBatchReceiveActor : IActorGrain, IGrainWithStringKey
+            { }
+
+            [StreamSubscription(Source = "sms:batched", Target = "#batched")]
+            public class TestBatchReceiveActor : TestConsumerActorBase, ITestBatchReceiveActor
+            { }
+
+            [TestFixture, RequiresSilo]
+            [Category("Slow")]
+            public class Tests
+            {
+                static TestCases Verify() => new TestCases("sms", TimeSpan.FromSeconds(5));
+
+                [Test] public async Task Client_to_stream() => await Verify().Client_to_stream<ITestClientToStreamConsumerActor>();
+                [Test] public async Task Actor_to_stream() => await Verify().Actor_to_stream<ITestActorToStreamConsumerActor>();
+                [Test] public async Task Multistream_subscription_with_fixed_ids() => await Verify().Multistream_subscription_with_fixed_ids<ITestMultistreamSubscriptionWithFixedIdsActor>();
+                [Test] public async Task Multistream_subscription_based_on_regex_matching() => await Verify().Multistream_subscription_based_on_regex_matching<ITestMultistreamRegexBasedSubscriptionActor>();
+                [Test] public async Task Declared_handler_only_automatic_item_filtering() => await Verify().Declared_handler_only_automatic_item_filtering<ITestDeclaredHandlerOnlyAutomaticFilterActor>();
+                [Test] public async Task Select_all_filter() => await Verify().Select_all_filter<ITestSelectAllFilterActor>();
+                [Test] public async Task Explicit_filter() => await Verify().Explicit_filter<ITestExplicitFilterActor>();
+                [Test] public async Task Dynamic_target_selection() => await Verify().Dynamic_target_selection<ITestDynamicTargetSelectorActor>();
+                [Test] public async Task Batch_receive() => await Verify().Batch_receive<ITestBatchReceiveActor>();
+            }
+        }
+    }
+}

--- a/Tests/Orleankka.Tests/Testing/TestActions.cs
+++ b/Tests/Orleankka.Tests/Testing/TestActions.cs
@@ -77,7 +77,8 @@ namespace Orleankka.Testing
                     .AddMemoryStreams("sms")
                     .UseInMemoryReminderService())
                 .UseOrleankka()
-                .UseOrleankkaLegacyFeatures();
+                .UseOrleankkaLegacyFeatures(x => x
+                    .RegisterPersistentStreamProviders("sms"));
 
             var host = sb.Build();
             host.StartAsync().Wait();


### PR DESCRIPTION
@yevhen i have attempted to re-add legacy stream subscriptions. 
You have a lot of knowledge with Orleans / previous implementations of stream subscriptions. Would you take a look at this implementation? Any comments would be greatly appreciated. Feel free to modify / adjust the code if needed.

If the implementation is sufficient would it be possible to re-add here on the Orleankka repo?

Related to #182